### PR TITLE
Use Arc all the way down

### DIFF
--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -734,18 +734,13 @@ impl SessionState {
     }
 
     /// return the configuration options
-    pub fn config_options(&self) -> &ConfigOptions {
+    pub fn config_options(&self) -> &Arc<ConfigOptions> {
         self.config.options()
-    }
-
-    /// return the configuration options
-    pub fn config_options_arc(&self) -> Arc<ConfigOptions> {
-        self.config.options_arc()
     }
 
     /// Mark the start of the execution
     pub fn start_execution(&mut self) {
-        let config = self.config.options_arc();
+        let config = Arc::clone(self.config.options());
         self.execution_props.start_execution(config);
     }
 
@@ -1899,7 +1894,7 @@ impl OptimizerConfig for SessionState {
     }
 
     fn options(&self) -> Arc<ConfigOptions> {
-        self.config_options_arc()
+        Arc::clone(self.config.options())
     }
 
     fn function_registry(&self) -> Option<&dyn FunctionRegistry> {

--- a/datafusion/core/tests/parquet/file_statistics.rs
+++ b/datafusion/core/tests/parquet/file_statistics.rs
@@ -38,6 +38,7 @@ use datafusion_execution::runtime_env::RuntimeEnvBuilder;
 use datafusion_expr::{col, lit, Expr};
 
 use datafusion::datasource::physical_plan::FileScanConfig;
+use datafusion_common::config::ConfigOptions;
 use datafusion_physical_optimizer::filter_pushdown::FilterPushdown;
 use datafusion_physical_optimizer::PhysicalOptimizerRule;
 use datafusion_physical_plan::filter::FilterExec;
@@ -55,7 +56,7 @@ async fn check_stats_precision_with_filter_pushdown() {
     let table = get_listing_table(&table_path, None, &opt).await;
 
     let (_, _, state) = get_cache_runtime_state();
-    let mut options = state.config().options().clone();
+    let mut options: ConfigOptions = state.config().options().as_ref().clone();
     options.execution.parquet.pushdown_filters = true;
 
     // Scan without filter, stats are exact

--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -136,13 +136,8 @@ impl SessionConfig {
     /// let config = SessionConfig::new();
     /// assert!(config.options().execution.batch_size > 0);
     /// ```
-    pub fn options(&self) -> &ConfigOptions {
+    pub fn options(&self) -> &Arc<ConfigOptions> {
         &self.options
-    }
-
-    /// Returns the config options as an Arc
-    pub fn options_arc(&self) -> Arc<ConfigOptions> {
-        Arc::clone(&self.options)
     }
 
     /// Return a mutable handle to the configuration options.

--- a/datafusion/physical-plan/src/async_func.rs
+++ b/datafusion/physical-plan/src/async_func.rs
@@ -176,7 +176,7 @@ impl ExecutionPlan for AsyncFuncExec {
         // now, for each record batch, evaluate the async expressions and add the columns to the result
         let async_exprs_captured = Arc::new(self.async_exprs.clone());
         let schema_captured = self.schema();
-        let config_options_ref = Arc::new(context.session_config().options().clone());
+        let config_options_ref = Arc::clone(context.session_config().options());
 
         let stream_with_async_functions = input_stream.then(move |batch| {
             // need to clone *again* to capture the async_exprs and schema in the


### PR DESCRIPTION
- This is a proposal for https://github.com/apache/datafusion/pull/16970 

It shows what is needed if we switch to using `&Arc<ConfigOptions>` in most places

It is technically a larger API change but I think it is eaiser to use and guides people to the correct usage